### PR TITLE
replace "syscall" with golang.org/x/sys/unix

### DIFF
--- a/ns/init_linux.go
+++ b/ns/init_linux.go
@@ -6,12 +6,12 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -64,7 +64,7 @@ func getHandler() netns.NsHandle {
 }
 
 func getLink() (string, error) {
-	return os.Readlink(fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), syscall.Gettid()))
+	return os.Readlink(fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid()))
 }
 
 // NlHandle returns the netlink handler
@@ -74,22 +74,22 @@ func NlHandle() *netlink.Handle {
 }
 
 func getSupportedNlFamilies() []int {
-	fams := []int{syscall.NETLINK_ROUTE}
+	fams := []int{unix.NETLINK_ROUTE}
 	// NETLINK_XFRM test
 	if err := checkXfrmSocket(); err != nil {
 		logrus.Warnf("Could not load necessary modules for IPSEC rules: %v", err)
 	} else {
-		fams = append(fams, syscall.NETLINK_XFRM)
+		fams = append(fams, unix.NETLINK_XFRM)
 	}
 	// NETLINK_NETFILTER test
 	if err := loadNfConntrackModules(); err != nil {
 		if checkNfSocket() != nil {
 			logrus.Warnf("Could not load necessary modules for Conntrack: %v", err)
 		} else {
-			fams = append(fams, syscall.NETLINK_NETFILTER)
+			fams = append(fams, unix.NETLINK_NETFILTER)
 		}
 	} else {
-		fams = append(fams, syscall.NETLINK_NETFILTER)
+		fams = append(fams, unix.NETLINK_NETFILTER)
 	}
 
 	return fams
@@ -97,11 +97,11 @@ func getSupportedNlFamilies() []int {
 
 // API check on required xfrm modules (xfrm_user, xfrm_algo)
 func checkXfrmSocket() error {
-	fd, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, syscall.NETLINK_XFRM)
+	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW, unix.NETLINK_XFRM)
 	if err != nil {
 		return err
 	}
-	syscall.Close(fd)
+	unix.Close(fd)
 	return nil
 }
 
@@ -117,10 +117,10 @@ func loadNfConntrackModules() error {
 
 // API check on required nf_conntrack* modules (nf_conntrack, nf_conntrack_netlink)
 func checkNfSocket() error {
-	fd, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, syscall.NETLINK_NETFILTER)
+	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW, unix.NETLINK_NETFILTER)
 	if err != nil {
 		return err
 	}
-	syscall.Close(fd)
+	unix.Close(fd)
 	return nil
 }


### PR DESCRIPTION
The go syscall package has been frozen since go1.4. Any new features,
and most updates for syscall are implemented in the golang.org/x/sys
package instead.
