### PR TITLE
netlink: remove redundant check

### DIFF
--- a/netlink.go
+++ b/netlink.go
@@ -219,9 +219,6 @@ done:
 	for {
 		msgs, _, err := s.Receive()
 		if err != nil {
-			if s.GetFd() == -1 {
-				return nil, fmt.Errorf("Socket got closed on receive")
-			}
 			if err == syscall.EAGAIN {
 				// timeout fired
 				continue


### PR DESCRIPTION
This check is already handled by NetLinkSocket.Receive() since vishvananda/netlink#125, so we can remove the check here.

noticed this while updating netlink in libnetwork
