### PR TITLE
Feature: support get ipvs info

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -54,6 +54,13 @@ const (
 	ipvsCmdAttrTimeoutUDP
 )
 
+// Attributes used to describe an info
+const (
+	ipvsCmdAttrInfoUnspec int = iota
+	ipvsCmdAttrInfoVersion
+	ipvsCmdAttrInfoConnTableSize
+)
+
 // Attributes used to describe a service. Used inside nested attribute
 // ipvsCmdAttrService
 const (

--- a/ipvs.go
+++ b/ipvs.go
@@ -74,6 +74,24 @@ type Config struct {
 	TimeoutUDP    time.Duration
 }
 
+// Info defines IPVS info
+type Info struct {
+	Version       *Version
+	ConnTableSize uint32
+}
+
+// Version defines IPVS version
+type Version struct {
+	Major uint
+	Minor uint
+	Patch uint
+}
+
+// String returns a string of IPVS version
+func (v *Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
 // Handle provides a namespace specific ipvs handle to program ipvs
 // rules.
 type Handle struct {
@@ -203,4 +221,22 @@ func (i *Handle) GetConfig() (*Config, error) {
 // SetConfig set the current timeout configuration. 0: no change
 func (i *Handle) SetConfig(c *Config) error {
 	return i.doSetConfigCmd(c)
+}
+
+// GetInfo returns info details from IPVS
+func (i *Handle) GetInfo() (*Info, error) {
+	res, err := i.doGetInfoCmd()
+	if err != nil {
+		return nil, err
+	}
+
+	ver := uint(res.version)
+	return &Info{
+		Version: &Version{
+			Major: (ver >> 16) & 0xff,
+			Minor: (ver >> 8) & 0xff,
+			Patch: ver & 0xff,
+		},
+		ConnTableSize: res.connTableSize,
+	}, nil
 }

--- a/ipvs_test.go
+++ b/ipvs_test.go
@@ -371,6 +371,19 @@ func TestTimeouts(t *testing.T) {
 	assert.DeepEqual(t, *c3, Config{77 * time.Second, 66 * time.Second, 77 * time.Second})
 }
 
+func TestInfo(t *testing.T) {
+	defer setupTestOSContext(t)
+
+	i, err := New("")
+	assert.NilError(t, err)
+
+	info, err := i.GetInfo()
+	assert.NilError(t, err)
+	assert.Check(t, info.Version != nil)
+	assert.Assert(t, info.Version.String() != "")
+	assert.Assert(t, info.ConnTableSize > 0)
+}
+
 // setupTestOSContext joins a new network namespace, and returns its associated
 // teardown function.
 //

--- a/netlink.go
+++ b/netlink.go
@@ -38,6 +38,11 @@ type ipvsFlags struct {
 	mask  uint32
 }
 
+type ipvsInfo struct {
+	version       uint32
+	connTableSize uint32
+}
+
 func deserializeGenlMsg(b []byte) (hdr *genlMsgHdr) {
 	return (*genlMsgHdr)(unsafe.Pointer(&b[0:unsafe.Sizeof(*hdr)][0]))
 }
@@ -571,6 +576,44 @@ func (i *Handle) doSetConfigCmd(c *Config) error {
 	_, err := execute(i.sock, req, 0)
 
 	return err
+}
+
+// parseInfo given a ipvs netlink response this function will respond with a valid info entry, an error otherwise
+func (i *Handle) parseInfo(msg []byte) (*ipvsInfo, error) {
+	var info ipvsInfo
+
+	hdr := deserializeGenlMsg(msg)
+	attrs, err := nl.ParseRouteAttr(msg[hdr.Len():])
+	if err != nil {
+		return nil, err
+	}
+
+	for _, attr := range attrs {
+		attrType := int(attr.Attr.Type)
+		switch attrType {
+		case ipvsCmdAttrInfoVersion:
+			info.version = native.Uint32(attr.Value)
+		case ipvsCmdAttrInfoConnTableSize:
+			info.connTableSize = native.Uint32(attr.Value)
+		}
+	}
+
+	return &info, nil
+}
+
+// doGetInfoCmd a wrapper function to be used by GetInfo
+func (i *Handle) doGetInfoCmd() (*ipvsInfo, error) {
+	msg, err := i.doCmdWithoutAttr(ipvsCmdGetInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := i.parseInfo(msg[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
 // IPVS related netlink message format explained


### PR DESCRIPTION
fetch ipvs info with API `info := i.GetInfo()`

fetch version number just call `info.Version.String()`, example: 1.2.1
fetch connection table size call `info.ConnTableSize`, example: 4096 .