### PR TITLE
rename IPVS stats attributes since they apply for both services and destinations

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -88,20 +88,20 @@ const (
 	ipvsDestAttrAddressFamily
 )
 
-// IPVS Svc Statistics constancs
+// IPVS Statistics constants
 
 const (
-	ipvsSvcStatsUnspec int = iota
-	ipvsSvcStatsConns
-	ipvsSvcStatsPktsIn
-	ipvsSvcStatsPktsOut
-	ipvsSvcStatsBytesIn
-	ipvsSvcStatsBytesOut
-	ipvsSvcStatsCPS
-	ipvsSvcStatsPPSIn
-	ipvsSvcStatsPPSOut
-	ipvsSvcStatsBPSIn
-	ipvsSvcStatsBPSOut
+	ipvsStatsUnspec int = iota
+	ipvsStatsConns
+	ipvsStatsPktsIn
+	ipvsStatsPktsOut
+	ipvsStatsBytesIn
+	ipvsStatsBytesOut
+	ipvsStatsCPS
+	ipvsStatsPPSIn
+	ipvsStatsPPSOut
+	ipvsStatsBPSIn
+	ipvsStatsBPSOut
 )
 
 // Destination forwarding methods

--- a/netlink.go
+++ b/netlink.go
@@ -286,25 +286,25 @@ func assembleStats(msg []byte) (SvcStats, error) {
 	for _, attr := range attrs {
 		attrType := int(attr.Attr.Type)
 		switch attrType {
-		case ipvsSvcStatsConns:
+		case ipvsStatsConns:
 			s.Connections = native.Uint32(attr.Value)
-		case ipvsSvcStatsPktsIn:
+		case ipvsStatsPktsIn:
 			s.PacketsIn = native.Uint32(attr.Value)
-		case ipvsSvcStatsPktsOut:
+		case ipvsStatsPktsOut:
 			s.PacketsOut = native.Uint32(attr.Value)
-		case ipvsSvcStatsBytesIn:
+		case ipvsStatsBytesIn:
 			s.BytesIn = native.Uint64(attr.Value)
-		case ipvsSvcStatsBytesOut:
+		case ipvsStatsBytesOut:
 			s.BytesOut = native.Uint64(attr.Value)
-		case ipvsSvcStatsCPS:
+		case ipvsStatsCPS:
 			s.CPS = native.Uint32(attr.Value)
-		case ipvsSvcStatsPPSIn:
+		case ipvsStatsPPSIn:
 			s.PPSIn = native.Uint32(attr.Value)
-		case ipvsSvcStatsPPSOut:
+		case ipvsStatsPPSOut:
 			s.PPSOut = native.Uint32(attr.Value)
-		case ipvsSvcStatsBPSIn:
+		case ipvsStatsBPSIn:
 			s.BPSIn = native.Uint32(attr.Value)
-		case ipvsSvcStatsBPSOut:
+		case ipvsStatsBPSOut:
 			s.BPSOut = native.Uint32(attr.Value)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

The IPVS stats attributes are intended to be used for both services and destinations so the constant names should also reflect that. See https://github.com/torvalds/linux/blob/6f7b841bc939e7c811ad32427b58d54edbcfa6ed/include/uapi/linux/ip_vs.h#L440-L460 for more details. 