### PR TITLE
Support for destination tunneling and propagate address family when filling the destination

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -88,20 +88,20 @@ const (
 	ipvsDestAttrAddressFamily
 )
 
-// IPVS Svc Statistics constancs
+// IPVS Statistics constants
 
 const (
-	ipvsSvcStatsUnspec int = iota
-	ipvsSvcStatsConns
-	ipvsSvcStatsPktsIn
-	ipvsSvcStatsPktsOut
-	ipvsSvcStatsBytesIn
-	ipvsSvcStatsBytesOut
-	ipvsSvcStatsCPS
-	ipvsSvcStatsPPSIn
-	ipvsSvcStatsPPSOut
-	ipvsSvcStatsBPSIn
-	ipvsSvcStatsBPSOut
+	ipvsStatsUnspec int = iota
+	ipvsStatsConns
+	ipvsStatsPktsIn
+	ipvsStatsPktsOut
+	ipvsStatsBytesIn
+	ipvsStatsBytesOut
+	ipvsStatsCPS
+	ipvsStatsPPSIn
+	ipvsStatsPPSOut
+	ipvsStatsBPSIn
+	ipvsStatsBPSOut
 )
 
 // Destination forwarding methods

--- a/constants.go
+++ b/constants.go
@@ -86,6 +86,10 @@ const (
 	ipvsDestAttrPersistentConnections
 	ipvsDestAttrStats
 	ipvsDestAttrAddressFamily
+	ipvsDestAttrStats64
+	ipvsDestAttrTunType
+	ipvsDestAttrTunPort
+	ipvsDestAttrTunFlags
 )
 
 // IPVS Statistics constants
@@ -175,4 +179,28 @@ const (
 
 	// ConnFwdBypass denotes forwarding while bypassing the cache
 	ConnFwdBypass = 0x0004
+)
+
+// Tunnel Types
+const (
+	TunnelTypeIPIP uint8 = iota
+	TunnelTypeGUE
+	TunnelTypeGRE
+)
+
+// Tunnel encapsulation flags
+const (
+	EncapFlagNoCSum  = 0
+	EncapFlagCSum    = 1 << 0
+	EncapFlagRemCSum = 1 << 1
+)
+
+// Virtual Service Flags
+const (
+	SchedulerFlag1 = 0x0008
+	SchedulerFlag2 = 0x0010
+	SchedulerFlag3 = 0x0020
+
+	SchedulerMHFallback = SchedulerFlag1
+	SchedulerMHPort     = SchedulerFlag2
 )

--- a/ipvs.go
+++ b/ipvs.go
@@ -62,6 +62,9 @@ type Destination struct {
 	ActiveConnections   int
 	InactiveConnections int
 	Stats               DstStats
+	TunType             uint8
+	TunPort             uint16
+	TunFlags            uint16
 }
 
 // DstStats defines IPVS destination (real server) statistics

--- a/netlink.go
+++ b/netlink.go
@@ -287,25 +287,25 @@ func assembleStats(msg []byte) (SvcStats, error) {
 	for _, attr := range attrs {
 		attrType := int(attr.Attr.Type)
 		switch attrType {
-		case ipvsSvcStatsConns:
+		case ipvsStatsConns:
 			s.Connections = native.Uint32(attr.Value)
-		case ipvsSvcStatsPktsIn:
+		case ipvsStatsPktsIn:
 			s.PacketsIn = native.Uint32(attr.Value)
-		case ipvsSvcStatsPktsOut:
+		case ipvsStatsPktsOut:
 			s.PacketsOut = native.Uint32(attr.Value)
-		case ipvsSvcStatsBytesIn:
+		case ipvsStatsBytesIn:
 			s.BytesIn = native.Uint64(attr.Value)
-		case ipvsSvcStatsBytesOut:
+		case ipvsStatsBytesOut:
 			s.BytesOut = native.Uint64(attr.Value)
-		case ipvsSvcStatsCPS:
+		case ipvsStatsCPS:
 			s.CPS = native.Uint32(attr.Value)
-		case ipvsSvcStatsPPSIn:
+		case ipvsStatsPPSIn:
 			s.PPSIn = native.Uint32(attr.Value)
-		case ipvsSvcStatsPPSOut:
+		case ipvsStatsPPSOut:
 			s.PPSOut = native.Uint32(attr.Value)
-		case ipvsSvcStatsBPSIn:
+		case ipvsStatsBPSIn:
 			s.BPSIn = native.Uint32(attr.Value)
-		case ipvsSvcStatsBPSOut:
+		case ipvsStatsBPSOut:
 			s.BPSOut = native.Uint32(attr.Value)
 		}
 	}

--- a/netlink.go
+++ b/netlink.go
@@ -110,7 +110,8 @@ func fillDestination(d *Destination) nl.NetlinkRequestData {
 	portBuf := new(bytes.Buffer)
 	binary.Write(portBuf, binary.BigEndian, d.Port)
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrPort, portBuf.Bytes())
-
+	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrAddressFamily, nl.Uint32Attr(uint32(d.AddressFamily)))
+	
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrForwardingMethod, nl.Uint32Attr(d.ConnectionFlags&ConnectionFlagFwdMask))
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrWeight, nl.Uint32Attr(uint32(d.Weight)))
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrUpperThreshold, nl.Uint32Attr(d.UpperThreshold))


### PR DESCRIPTION
This PR adds support for configuring tunneling (IPIP, GUE, GRE), port and any respective flags for an IPVS destination. 

This also introduces a change that specifies the address family when destination is filled. In our development and testing we noticed that adding a backend to IPVS through the library where the backend has an IPv6 address, resulted in the first 32 bits of that IPv6 address getting interpreted as an IPv4 address. This was fixed by specifying `ipvsDestAttrAddressFamily` in `fillDestination`. 