### PR TITLE
Support for destination tunneling and propagate address family when filling the destination

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -86,6 +86,10 @@ const (
 	ipvsDestAttrPersistentConnections
 	ipvsDestAttrStats
 	ipvsDestAttrAddressFamily
+	ipvsDestAttrStats64
+	ipvsDestAttrTunType
+	ipvsDestAttrTunPort
+	ipvsDestAttrTunFlags
 )
 
 // IPVS Statistics constants
@@ -175,4 +179,28 @@ const (
 
 	// ConnFwdBypass denotes forwarding while bypassing the cache
 	ConnFwdBypass = 0x0004
+)
+
+// Tunnel Types
+const (
+	TunnelTypeIPIP uint8 = iota
+	TunnelTypeGUE
+	TunnelTypeGRE
+)
+
+// Tunnel encapsulation flags
+const (
+	EncapFlagNoCSum  = 0
+	EncapFlagCSum    = 1 << 0
+	EncapFlagRemCSum = 1 << 1
+)
+
+// Virtual Service Flags
+const (
+	SchedulerFlag1 = 0x0008
+	SchedulerFlag2 = 0x0010
+	SchedulerFlag3 = 0x0020
+
+	SchedulerMHFallback = SchedulerFlag1
+	SchedulerMHPort     = SchedulerFlag2
 )

--- a/ipvs.go
+++ b/ipvs.go
@@ -62,6 +62,9 @@ type Destination struct {
 	ActiveConnections   int
 	InactiveConnections int
 	Stats               DstStats
+	TunType             uint8
+	TunPort             uint16
+	TunFlags            uint16
 }
 
 // DstStats defines IPVS destination (real server) statistics

--- a/netlink.go
+++ b/netlink.go
@@ -110,8 +110,8 @@ func fillDestination(d *Destination) nl.NetlinkRequestData {
 	portBuf := new(bytes.Buffer)
 	binary.Write(portBuf, binary.BigEndian, d.Port)
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrPort, portBuf.Bytes())
-	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrAddressFamily, nl.Uint32Attr(uint32(d.AddressFamily)))
-	
+	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrAddressFamily, nl.Uint16Attr(d.AddressFamily))
+
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrForwardingMethod, nl.Uint32Attr(d.ConnectionFlags&ConnectionFlagFwdMask))
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrWeight, nl.Uint32Attr(uint32(d.Weight)))
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrUpperThreshold, nl.Uint32Attr(d.UpperThreshold))

--- a/netlink.go
+++ b/netlink.go
@@ -110,7 +110,8 @@ func fillDestination(d *Destination) nl.NetlinkRequestData {
 	portBuf := new(bytes.Buffer)
 	binary.Write(portBuf, binary.BigEndian, d.Port)
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrPort, portBuf.Bytes())
-
+	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrAddressFamily, nl.Uint32Attr(uint32(d.AddressFamily)))
+	
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrForwardingMethod, nl.Uint32Attr(d.ConnectionFlags&ConnectionFlagFwdMask))
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrWeight, nl.Uint32Attr(uint32(d.Weight)))
 	nl.NewRtAttrChild(cmdAttr, ipvsDestAttrUpperThreshold, nl.Uint32Attr(d.UpperThreshold))


### PR DESCRIPTION
This PR adds support for configuring tunneling (IPIP, GUE, GRE), port and any respective flags for an IPVS destination.

This also introduces a change that specifies the address family when destination is filled. In our development and testing we noticed that adding a backend to IPVS through the library where the backend has an IPv6 address, resulted in the first 32 bits of that IPv6 address getting interpreted as an IPv4 address. This was fixed by specifying ipvsDestAttrAddressFamily in `fillDestination`. 

Apologies for opening and closing the same PR a bunch of times. GitHub was suggesting an incorrect rebase for signoff.