### PR TITLE
Correct data types for connection counts

### DIFF
--- a/netlink.go
+++ b/netlink.go
@@ -447,9 +447,9 @@ func assembleDestination(attrs []syscall.NetlinkRouteAttr) (*Destination, error)
 		case ipvsDestAttrLowerThreshold:
 			d.LowerThreshold = native.Uint32(attr.Value)
 		case ipvsDestAttrActiveConnections:
-			d.ActiveConnections = int(native.Uint16(attr.Value))
+			d.ActiveConnections = int(native.Uint32(attr.Value))
 		case ipvsDestAttrInactiveConnections:
-			d.InactiveConnections = int(native.Uint16(attr.Value))
+			d.InactiveConnections = int(native.Uint32(attr.Value))
 		case ipvsDestAttrStats:
 			stats, err := assembleStats(attr.Value)
 			if err != nil {


### PR DESCRIPTION
- fixes https://github.com/moby/ipvs/issues/25

These values are emitted as 32 bit unsigned integers from the kernel. See https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/netfilter/ipvs/ip_vs_ctl.c#n2999 and https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/netfilter/ipvs/ip_vs_ctl.c#n3317.